### PR TITLE
chore: Changes compose deployment name.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-name: zarrcade
+name: fileglancer-central
 services:
 
     webapp:


### PR DESCRIPTION
The deployment was showing up as zarrcade in the docker containers
listing as opposed to fileglancer
