### PR TITLE
Refactor file share paths

### DIFF
--- a/fileglancer_central/app.py
+++ b/fileglancer_central/app.py
@@ -18,11 +18,11 @@ from fileglancer_central.issues import create_jira_ticket, get_jira_ticket_detai
 
 class FileSharePath(BaseModel):
     """A file share path from the database"""
+    name: str = Field(
+        description="The name of the file share, which uniquely identifies the file share."
+    )
     zone: str = Field(
         description="The zone of the file share, for grouping paths in the UI."
-    )
-    canonical_path: str = Field(
-        description="The canonical path to the file share, which uniquely identifies the file share."
     )
     group: Optional[str] = Field(
         description="The group that owns the file share",
@@ -31,6 +31,9 @@ class FileSharePath(BaseModel):
     storage: Optional[str] = Field(
         description="The storage type of the file share (home, primary, scratch, etc.)",
         default=None
+    )
+    mount_path: str = Field(
+        description="The path where the file share is mounted on the local machine"
     )
     mac_path: Optional[str] = Field(
         description="The path used to mount the file share on Mac (e.g. smb://server/share)",
@@ -182,10 +185,11 @@ def create_app(settings):
                     update_file_share_paths(session, table, table_last_updated)
 
             paths = [FileSharePath(
-                        zone=path.lab,
+                        name=path.name,
+                        zone=path.zone,
                         group=path.group,
                         storage=path.storage,
-                        canonical_path=path.canonical_path,
+                        mount_path=path.mount_path,
                         mac_path=path.mac_path, 
                         windows_path=path.windows_path,
                         linux_path=path.linux_path,

--- a/fileglancer_central/app.py
+++ b/fileglancer_central/app.py
@@ -214,7 +214,7 @@ def create_app(settings):
             description=description
         )
         return ticket['key']
-
+    
 
     @app.get("/ticket/{ticket_key}", response_model=Ticket, 
              description="Retrieve a ticket by its key")
@@ -236,49 +236,6 @@ def create_app(settings):
             return {"message": f"Ticket {ticket_key} deleted"}
         except Exception as e:
             if str(e) == "Issue Does Not Exist":
-                raise HTTPException(status_code=404, detail=str(e))
-            else:
-                raise HTTPException(status_code=500, detail=str(e))
-
-
-
-    @app.post("/ticket", response_model=str,
-              description="Create a new ticket and return the key")
-    async def create_ticket(
-        project_key: str,
-        issue_type: str,
-        summary: str,
-        description: str
-    ) -> str:
-        ticket = create_jira_ticket(
-            project_key=project_key,
-            issue_type=issue_type, 
-            summary=summary,
-            description=description
-        )
-        return ticket['key']
-
-
-    @app.get("/ticket/{ticket_key}", response_model=Ticket, 
-             description="Get a ticket by key")
-    async def get_ticket(ticket_key: str):
-        try:
-            return get_jira_ticket_details(ticket_key)
-        except Exception as e:
-            if e.message == "Issue Does Not Exist":
-                raise HTTPException(status_code=404, detail=str(e))
-            else:
-                raise HTTPException(status_code=500, detail=str(e))
-
-
-    @app.delete("/ticket/{ticket_key}",
-                description="Delete a ticket")
-    async def delete_ticket(ticket_key: str):
-        try:
-            delete_jira_ticket(ticket_key)
-            return {"message": f"Ticket {ticket_key} deleted"}
-        except Exception as e:
-            if e.message == "Issue Does Not Exist":
                 raise HTTPException(status_code=404, detail=str(e))
             else:
                 raise HTTPException(status_code=500, detail=str(e))

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -53,8 +53,8 @@ def test_file_share_paths(db_session):
     # Test get_all_paths
     paths = get_all_paths(db_session)
     assert len(paths) == 2
-    assert paths[0].lab == 'lab1'
-    assert paths[1].lab == 'lab2'
+    assert paths[0].zone == 'lab1'
+    assert paths[1].zone == 'lab2'
 
     # Test updating existing paths
     data['lab'] = ['lab1_updated', 'lab2_updated']
@@ -62,8 +62,8 @@ def test_file_share_paths(db_session):
     update_file_share_paths(db_session, df, datetime.now())
     
     paths = get_all_paths(db_session)
-    assert paths[0].lab == 'lab1_updated'
-    assert paths[1].lab == 'lab2_updated'
+    assert paths[0].zone == 'lab1_updated'
+    assert paths[1].zone == 'lab2_updated'
 
 
 def test_last_refresh(db_session):

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -36,7 +36,7 @@ def test_docs_redirect(test_client):
 
 def test_get_preferences(test_client):
     """Test getting user preferences"""
-    response = test_client.get("/preferences/testuser")
+    response = test_client.get("/preference/testuser")
     assert response.status_code == 200
     value = response.json()
     assert isinstance(value, dict)
@@ -45,25 +45,25 @@ def test_get_preferences(test_client):
 
 def test_get_specific_preference(test_client):
     """Test getting specific user preference"""
-    response = test_client.get("/preferences/testuser/unknown_key")
+    response = test_client.get("/preference/testuser/unknown_key")
     assert response.status_code == 404
 
 
 def test_set_preference(test_client):
     """Test setting user preference"""
     pref_data = {"test": "value"}
-    response = test_client.put("/preferences/testuser/test_key", json=pref_data)
+    response = test_client.put("/preference/testuser/test_key", json=pref_data)
     assert response.status_code == 200
 
-    response = test_client.get("/preferences/testuser/test_key")
+    response = test_client.get("/preference/testuser/test_key")
     assert response.status_code == 200
     assert response.json() == pref_data
 
 
 def test_delete_preference(test_client):
     """Test deleting user preference"""
-    response = test_client.delete("/preferences/testuser/test_key")
+    response = test_client.delete("/preference/testuser/test_key")
     assert response.status_code == 200
 
-    response = test_client.delete("/preferences/testuser/unknown_key")
+    response = test_client.delete("/preference/testuser/unknown_key")
     assert response.status_code == 404


### PR DESCRIPTION
@allison-truhlar @neomorphic @StephanPreibisch 

This PR refactors file share paths to clean up the attribute naming:
* `canonical_path` → `name` and `mount_path`
* `lab` → `zone`

The `name` is now a slugified identifier that can be used to refer uniquely to each file share path. The `mount_path` is how we expect the files to be mounted and accessible on the server side. 

There are also some other clean ups included. 