### PR TITLE
Custom file share mounts

### DIFF
--- a/config.yaml.template
+++ b/config.yaml.template
@@ -9,6 +9,13 @@ log_level: INFO
 db_url: sqlite:///fileglancer.db
 
 #
+# File share mount paths to view in the UI. 
+# (this setting is ignored if confluence_url is set below)
+#
+file_share_mounts:
+  - /tmp
+
+#
 # Confluence URL
 #
 confluence_url: https://wikis.janelia.org 

--- a/fileglancer_central/app.py
+++ b/fileglancer_central/app.py
@@ -1,4 +1,3 @@
-import re
 import sys
 from datetime import datetime
 from typing import List, Optional, Dict
@@ -46,7 +45,6 @@ def cache_wiki_paths(confluence_url, confluence_token, force_refresh=False):
             linux_path=path.linux_path,
         ) for path in get_all_paths(session)]
         
-
 
 def create_app(settings):
 

--- a/fileglancer_central/app.py
+++ b/fileglancer_central/app.py
@@ -15,7 +15,7 @@ from fileglancer_central.settings import get_settings
 from fileglancer_central.database import get_db_session, get_all_paths, get_last_refresh, update_file_share_paths, get_user_preference, set_user_preference, delete_user_preference, get_all_user_preferences, FileSharePathDB
 from fileglancer_central.wiki import get_wiki_table, convert_table_to_file_share_paths
 from fileglancer_central.issues import create_jira_ticket, get_jira_ticket_details, delete_jira_ticket
-
+from fileglancer_central.utils import slugify_path
 
 def cache_wiki_paths(confluence_url, confluence_token, force_refresh=False):
     with get_db_session() as session:
@@ -114,14 +114,14 @@ def create_app(settings):
             paths = cache_wiki_paths(confluence_url, confluence_token, force_refresh)
         else:
             paths = [FileSharePath(
-                name=path.name,
-                zone=path.zone,
-                group=path.group,
-                storage=path.storage,
-                mount_path=path.mount_path,
-                mac_path=path.mac_path,
-                windows_path=path.windows_path,
-                linux_path=path.linux_path,
+                name=slugify_path(path),
+                zone='Local',
+                group='local',
+                storage='local',
+                mount_path=path,
+                mac_path=path,
+                windows_path=path,
+                linux_path=path,
             ) for path in file_share_mounts]
 
         return FileSharePathResponse(paths=paths)

--- a/fileglancer_central/app.py
+++ b/fileglancer_central/app.py
@@ -1,3 +1,4 @@
+import re
 import sys
 from datetime import datetime
 from typing import List, Optional, Dict
@@ -8,117 +9,44 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse, JSONResponse
 from fastapi.exceptions import RequestValidationError, StarletteHTTPException
-from pydantic import BaseModel, Field, HttpUrl
 
+from fileglancer_central.model import FileSharePath, FileSharePathResponse, Ticket
 from fileglancer_central.settings import get_settings
-from fileglancer_central.database import get_db_session, get_all_paths, get_last_refresh, update_file_share_paths, get_user_preference, set_user_preference, delete_user_preference, get_all_user_preferences
-from fileglancer_central.wiki import get_wiki_table
+from fileglancer_central.database import get_db_session, get_all_paths, get_last_refresh, update_file_share_paths, get_user_preference, set_user_preference, delete_user_preference, get_all_user_preferences, FileSharePathDB
+from fileglancer_central.wiki import get_wiki_table, convert_table_to_file_share_paths
 from fileglancer_central.issues import create_jira_ticket, get_jira_ticket_details, delete_jira_ticket
 
 
-class FileSharePath(BaseModel):
-    """A file share path from the database"""
-    name: str = Field(
-        description="The name of the file share, which uniquely identifies the file share."
-    )
-    zone: str = Field(
-        description="The zone of the file share, for grouping paths in the UI."
-    )
-    group: Optional[str] = Field(
-        description="The group that owns the file share",
-        default=None
-    )
-    storage: Optional[str] = Field(
-        description="The storage type of the file share (home, primary, scratch, etc.)",
-        default=None
-    )
-    mount_path: str = Field(
-        description="The path where the file share is mounted on the local machine"
-    )
-    mac_path: Optional[str] = Field(
-        description="The path used to mount the file share on Mac (e.g. smb://server/share)",
-        default=None
-    )
-    windows_path: Optional[str] = Field(
-        description="The path used to mount the file share on Windows (e.g. \\\\server\\share)",
-        default=None
-    )
-    linux_path: Optional[str] = Field(
-        description="The path used to mount the file share on Linux (e.g. /unix/style/path)",
-        default=None
-    )
+def cache_wiki_paths(confluence_url, confluence_token, force_refresh=False):
+    with get_db_session() as session:
+        # Get the last refresh time from the database
+        last_refresh = get_last_refresh(session)
 
-class FileSharePathResponse(BaseModel):
-    paths: List[FileSharePath] = Field(
-        description="A list of file share paths"
-    )
-    
-class TicketComment(BaseModel):
-    """A comment on a ticket"""
-    author_name: str = Field(
-        description="The author of the comment"
-    )
-    author_display_name: str = Field(
-        description="The display name of the author"
-    )
-    body: str = Field(
-        description="The body of the comment"
-    )
-    
-class TicketComment(BaseModel):
-    """A comment on a ticket"""
-    author_name: str = Field(
-        description="The author of the comment"
-    )
-    author_display_name: str = Field(
-        description="The display name of the author"
-    )
-    body: str = Field(
-        description="The body of the comment"
-    )
-    created: datetime = Field(
-        description="The date and time the comment was created"
-    )
-    updated: datetime = Field(
-        description="The date and time the comment was updated"
-    )
+        # Check if we need to refresh the file share paths
+        if not last_refresh or (datetime.now() - last_refresh.db_last_updated).days >= 1 or force_refresh:
+            logger.info("Last refresh was more than a day ago, checking for updates...")
+            
+            # Get updated paths from the wiki
+            table, table_last_updated = get_wiki_table(confluence_url, confluence_token)
 
-class Ticket(BaseModel):
-    """A JIRA ticket"""
-    key: str = Field(
-        description="The key of the ticket"
-    )
-    created: datetime = Field(
-        description="The date and time the ticket was created"
-    )
-    updated: datetime = Field(
-        description="The date and time the ticket was updated"
-    )
-    status: str = Field(
-        description="The status of the ticket"
-    )
-    resolution: str = Field(
-        description="The resolution of the ticket"
-    )
-    description: str = Field(
-        description="The description of the ticket"
-    )
-    link: HttpUrl = Field(
-        description="The link to the ticket"
-    )
-    comments: List[TicketComment] = Field(
-        description="The comments on the ticket"
-    )
-    
+            new_paths = convert_table_to_file_share_paths(table)
 
-class UserPreference(BaseModel):
-    """A user preference"""
-    key: str = Field(
-        description="The key of the preference"
-    )
-    value: Dict = Field(
-        description="The value of the preference"
-    )
+            if not last_refresh or table_last_updated != last_refresh.source_last_updated:
+                logger.info("Wiki table has changed, refreshing file share paths...")
+                update_file_share_paths(session, new_paths, table_last_updated)
+
+        return [FileSharePath(
+            name=path.name,
+            zone=path.zone,
+            group=path.group,
+            storage=path.storage,
+            mount_path=path.mount_path,
+            mac_path=path.mac_path, 
+            windows_path=path.windows_path,
+            linux_path=path.linux_path,
+        ) for path in get_all_paths(session)]
+        
+
 
 def create_app(settings):
 
@@ -174,39 +102,29 @@ def create_app(settings):
     @app.get("/file-share-paths", response_model=FileSharePathResponse, 
              description="Get all file share paths from the database")
     async def get_file_share_paths(force_refresh: bool = False) -> List[FileSharePath]:
-        with get_db_session() as session:
-            last_refresh = get_last_refresh(session)
-            if not last_refresh or (datetime.now() - last_refresh.db_last_updated).days >= 1 or force_refresh:
-                logger.info("Last refresh was more than a day ago, checking for updates...")
-                confluence_url = app.settings.confluence_url
-                confluence_token = app.settings.confluence_token
-                if not confluence_url:
-                    logger.error("You must configure `confluence_url` in the config.yaml file or set `fgc_confluence_url` in the environment.")
-                    raise HTTPException(status_code=500, detail="Confluence is not configured")
-                
-                if not confluence_token:
-                    logger.error("You must configure `confluence_token` in the config.yaml file or set `fgc_confluence_token` in the environment.")
-                    raise HTTPException(status_code=500, detail="Confluence is not configured")
-                
-                table, table_last_updated = get_wiki_table(confluence_url, confluence_token)
-
-                if not last_refresh or table_last_updated != last_refresh.source_last_updated:
-                    logger.info("Wiki table has changed, refreshing file share paths...")
-                    update_file_share_paths(session, table, table_last_updated)
-
+        
+        confluence_url = app.settings.confluence_url
+        confluence_token = app.settings.confluence_token
+        file_share_mounts = app.settings.file_share_mounts
+        if not confluence_url and not confluence_token and not file_share_mounts:
+            logger.error("You must configure `confluence_url` and `confluence_token` or set `file_share_mounts`.")
+            raise HTTPException(status_code=500, detail="Confluence is not configured")
+        
+        if confluence_url and confluence_token:
+            paths = cache_wiki_paths(confluence_url, confluence_token, force_refresh)
+        else:
             paths = [FileSharePath(
-                        name=path.name,
-                        zone=path.zone,
-                        group=path.group,
-                        storage=path.storage,
-                        mount_path=path.mount_path,
-                        mac_path=path.mac_path, 
-                        windows_path=path.windows_path,
-                        linux_path=path.linux_path,
-                    ) for path in get_all_paths(session)]
+                name=path.name,
+                zone=path.zone,
+                group=path.group,
+                storage=path.storage,
+                mount_path=path.mount_path,
+                mac_path=path.mac_path,
+                windows_path=path.windows_path,
+                linux_path=path.linux_path,
+            ) for path in file_share_mounts]
 
         return FileSharePathResponse(paths=paths)
-
 
 
     @app.post("/ticket", response_model=str,

--- a/fileglancer_central/app.py
+++ b/fileglancer_central/app.py
@@ -16,6 +16,8 @@ from fileglancer_central.wiki import get_wiki_table, convert_table_to_file_share
 from fileglancer_central.issues import create_jira_ticket, get_jira_ticket_details, delete_jira_ticket
 from fileglancer_central.utils import slugify_path
 
+
+
 def cache_wiki_paths(confluence_url, confluence_token, force_refresh=False):
     with get_db_session() as session:
         # Get the last refresh time from the database
@@ -70,21 +72,16 @@ def create_app(settings):
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
-        # Setup
-        if callable(settings):
-            app.settings = settings()
-        else:
-            app.settings = settings
 
         # Configure logging based on the log level in the settings
         logger.remove()
-        logger.add(sys.stderr, level=app.settings.log_level)
+        logger.add(sys.stderr, level=settings.log_level)
 
         logger.info(f"Settings:")
-        logger.info(f"  log_level: {app.settings.log_level}")
-        logger.info(f"  db_url: {app.settings.db_url}")
-        logger.info(f"  confluence_url: {app.settings.confluence_url}")
-        logger.info(f"  jira_url: {app.settings.jira_url}")
+        logger.info(f"  log_level: {settings.log_level}")
+        logger.info(f"  db_url: {settings.db_url}")
+        logger.info(f"  confluence_url: {settings.confluence_url}")
+        logger.info(f"  jira_url: {settings.jira_url}")
         
         logger.info(f"Server ready")
         yield
@@ -101,9 +98,9 @@ def create_app(settings):
              description="Get all file share paths from the database")
     async def get_file_share_paths(force_refresh: bool = False) -> List[FileSharePath]:
         
-        confluence_url = app.settings.confluence_url
-        confluence_token = app.settings.confluence_token
-        file_share_mounts = app.settings.file_share_mounts
+        confluence_url = settings.confluence_url
+        confluence_token = settings.confluence_token
+        file_share_mounts = settings.file_share_mounts
         if not confluence_url and not confluence_token and not file_share_mounts:
             logger.error("You must configure `confluence_url` and `confluence_token` or set `file_share_mounts`.")
             raise HTTPException(status_code=500, detail="Confluence is not configured")
@@ -205,7 +202,7 @@ def create_app(settings):
     return app
 
 
-app = create_app(get_settings)
+app = create_app(get_settings())
 
 if __name__ == "__main__":
     import uvicorn

--- a/fileglancer_central/model.py
+++ b/fileglancer_central/model.py
@@ -1,0 +1,110 @@
+from datetime import datetime
+from typing import List, Optional, Dict
+
+from pydantic import BaseModel, Field, HttpUrl
+
+
+class FileSharePath(BaseModel):
+    """A file share path from the database"""
+    name: str = Field(
+        description="The name of the file share, which uniquely identifies the file share."
+    )
+    zone: str = Field(
+        description="The zone of the file share, for grouping paths in the UI."
+    )
+    group: Optional[str] = Field(
+        description="The group that owns the file share",
+        default=None
+    )
+    storage: Optional[str] = Field(
+        description="The storage type of the file share (home, primary, scratch, etc.)",
+        default=None
+    )
+    mount_path: str = Field(
+        description="The path where the file share is mounted on the local machine"
+    )
+    mac_path: Optional[str] = Field(
+        description="The path used to mount the file share on Mac (e.g. smb://server/share)",
+        default=None
+    )
+    windows_path: Optional[str] = Field(
+        description="The path used to mount the file share on Windows (e.g. \\\\server\\share)",
+        default=None
+    )
+    linux_path: Optional[str] = Field(
+        description="The path used to mount the file share on Linux (e.g. /unix/style/path)",
+        default=None
+    )
+
+class FileSharePathResponse(BaseModel):
+    paths: List[FileSharePath] = Field(
+        description="A list of file share paths"
+    )
+    
+class TicketComment(BaseModel):
+    """A comment on a ticket"""
+    author_name: str = Field(
+        description="The author of the comment"
+    )
+    author_display_name: str = Field(
+        description="The display name of the author"
+    )
+    body: str = Field(
+        description="The body of the comment"
+    )
+    
+class TicketComment(BaseModel):
+    """A comment on a ticket"""
+    author_name: str = Field(
+        description="The author of the comment"
+    )
+    author_display_name: str = Field(
+        description="The display name of the author"
+    )
+    body: str = Field(
+        description="The body of the comment"
+    )
+    created: datetime = Field(
+        description="The date and time the comment was created"
+    )
+    updated: datetime = Field(
+        description="The date and time the comment was updated"
+    )
+
+class Ticket(BaseModel):
+    """A JIRA ticket"""
+    key: str = Field(
+        description="The key of the ticket"
+    )
+    created: datetime = Field(
+        description="The date and time the ticket was created"
+    )
+    updated: datetime = Field(
+        description="The date and time the ticket was updated"
+    )
+    status: str = Field(
+        description="The status of the ticket"
+    )
+    resolution: str = Field(
+        description="The resolution of the ticket"
+    )
+    description: str = Field(
+        description="The description of the ticket"
+    )
+    link: HttpUrl = Field(
+        description="The link to the ticket"
+    )
+    comments: List[TicketComment] = Field(
+        description="The comments on the ticket"
+    )
+    
+
+class UserPreference(BaseModel):
+    """A user preference"""
+    key: str = Field(
+        description="The key of the preference"
+    )
+    value: Dict = Field(
+        description="The value of the preference"
+    )
+

--- a/fileglancer_central/settings.py
+++ b/fileglancer_central/settings.py
@@ -11,6 +11,7 @@ from pydantic_settings import (
     YamlConfigSettingsSource
 )
 from loguru import logger
+    
 
 class Settings(BaseSettings):
     """ Settings can be read from a settings.yaml file, 
@@ -21,8 +22,16 @@ class Settings(BaseSettings):
 
     log_level: str = 'DEBUG'
     db_url: str = 'sqlite:///fileglancer.db'
+
+    # Confluence settings for getting the institutional file share paths
     confluence_url: Optional[HttpUrl] = None
     confluence_token: Optional[str] = None
+
+    # If confluence settings are not provided, use a static list of paths to mount as file shares
+    # This can specify the home directory using a ~/ prefix.
+    file_share_mounts: List[str] = []
+    
+    # JIRA settings for managing tickets
     jira_url: Optional[HttpUrl] = None
     jira_token: Optional[str] = None
 

--- a/fileglancer_central/utils.py
+++ b/fileglancer_central/utils.py
@@ -1,0 +1,12 @@
+import re
+
+
+def slugify_path(s):
+    """Slugify a path to make it into a name"""
+    # Replace any special characters with underscores
+    s = re.sub(r'[^a-zA-Z0-9]', '_', s)
+    # Replace multiple underscores with a single underscore
+    s = re.sub(r'_+', '_', s)
+    # Remove leading underscores
+    s = s.lstrip('_')
+    return s

--- a/fileglancer_central/wiki.py
+++ b/fileglancer_central/wiki.py
@@ -13,6 +13,10 @@ from datetime import datetime
 from atlassian import Confluence
 from .settings import get_settings
 from loguru import logger
+
+from fileglancer_central.database import FileSharePathDB
+from fileglancer_central.utils import slugify_path
+
 settings = get_settings()
 
 confluence_space = "SCS"
@@ -55,3 +59,17 @@ def get_wiki_table(confluence_url, confluence_token):
 
     logger.debug(f"Found {len(table)} file share paths in the wiki")  
     return table, table_last_updated
+
+
+def convert_table_to_file_share_paths(table):
+    """Convert the wiki table to a list of DB objects"""
+    return [FileSharePathDB(
+        name=slugify_path(row.linux_path),
+        zone=row.lab,
+        group=row.group,
+        storage=row.storage,
+        mount_path=row.linux_path,
+        mac_path=row.mac_path,
+        windows_path=row.windows_path,
+        linux_path=row.linux_path,
+    ) for row in table.itertuples(index=False)]


### PR DESCRIPTION
You can now comment out the `confluence_url` in your `config.yaml` and instead provide a list of local paths that should show up in the UI. This is much better for testing, so that you can point it to your local OME-Zarr data. See the `config.yaml.template` for an example of how to set this up.

```
#
# Loguru logging level (ERROR, WARNING, INFO, DEBUG, TRACE)
#
log_level: INFO

#
# Database URL
#
db_url: sqlite:///fileglancer.db

#
# File share mount paths to view in the 
# (this setting is ignored if confluence_url is set below)
#
file_share_mounts:
  - /Users/rokickik/dev/fileglancer-central
  - /Users/rokickik/Documents/test_data
  - /tmp

#
# Confluence URL
#
#confluence_url: https://wikis.janelia.org

#
# JIRA URL
#
jira_url: https://issues.hhmi.org/issues
```

@allison-truhlar @neomorphic @StephanPreibisch 