### PR TITLE
fix: Removes owner attribute from FileSharePath model.

### DIFF
--- a/fileglancer_central/model.py
+++ b/fileglancer_central/model.py
@@ -12,9 +12,6 @@ class FileSharePath(BaseModel):
     zone: str = Field(
         description="The zone of the file share, for grouping paths in the UI."
     )
-    owner: str = Field(
-        description="The owner of the file share."
-    )
     group: Optional[str] = Field(
         description="The group that owns the file share",
         default=None


### PR DESCRIPTION
This was causing a pydantic error, because the owner value was not set.
I checked with @cgoina and he said the owner value should not be there
and should be in a different location. Deleting it results in the
correct 200 response from the server when requesting the
/file-share-paths endpoint.
