### PR TITLE
Wrap user proxied paths in an object instead of returning a list

### DIFF
--- a/fileglancer_central/model.py
+++ b/fileglancer_central/model.py
@@ -111,6 +111,7 @@ class UserPreference(BaseModel):
         description="The value of the preference"
     )
 
+
 class ProxiedPath(BaseModel):
     """A proxied path which is used to share a file system path via a URL"""
     username: str = Field(
@@ -124,4 +125,10 @@ class ProxiedPath(BaseModel):
     )
     mount_path: str = Field(
         description="The root path on the file system to be proxied"
+    )
+
+
+class ProxiedPathResponse(BaseModel):
+    paths: List[ProxiedPath] = Field(
+        description="A list of proxied paths"
     )

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -102,8 +102,10 @@ def test_get_proxied_paths(test_client, temp_dir):
     response = test_client.get(f"/proxied-path/testuser")
     assert response.status_code == 200
     data = response.json()
-    assert isinstance(data, list)
-    assert len(data) > 1
+    assert isinstance(data, dict)
+    assert "paths" in data
+    assert isinstance(data["paths"], list)
+    assert len(data["paths"]) > 1
 
 
 def test_update_proxied_path(test_client, temp_dir):


### PR DESCRIPTION
Return all user proxied paths in a JSON object as the paths field