### PR TITLE
Server URLs with proxied paths

### DIFF
--- a/config.yaml.template
+++ b/config.yaml.template
@@ -30,3 +30,8 @@ confluence_url: https://wikis.janelia.org
 #
 jira_url: https://issues.hhmi.org/issues
 
+#
+# External URL for proxied paths
+#
+external_proxy_url: http://localhost:7878/files
+

--- a/fileglancer_central/model.py
+++ b/fileglancer_central/model.py
@@ -114,6 +114,7 @@ class ProxiedPath(BaseModel):
     username: str = Field(
         description="The username of the user who owns this proxied path"
     )
+    # TODO: does this need to be exposed in the API? It's already included in the URL.
     sharing_key: str = Field(
         description="The sharing key is part of the URL proxy path. It is used to uniquely identify the proxied path."
     )
@@ -132,7 +133,9 @@ class ProxiedPath(BaseModel):
     updated_at: datetime = Field(
         description="When this proxied path was last updated"
     )
-
+    url: HttpUrl = Field(
+        description="The URL for accessing the data via the proxy"
+    )
 
 class ProxiedPathResponse(BaseModel):
     paths: List[ProxiedPath] = Field(

--- a/fileglancer_central/settings.py
+++ b/fileglancer_central/settings.py
@@ -38,6 +38,10 @@ class Settings(BaseSettings):
     jira_url: Optional[HttpUrl] = None
     jira_token: Optional[str] = None
 
+    # The external URL of the proxy server for accessing proxied paths.
+    # Maps to the /files/ end points of the fileglancer-central app.
+    external_proxy_url: Optional[HttpUrl] = None
+
     model_config = SettingsConfigDict(
         yaml_file="config.yaml",
         env_file='.env',


### PR DESCRIPTION
Added a new setting for the external proxy URL. In dev this is something like `http://localhost:8989/files` but in production it's proxied with Nginx and becomes e.g. `https://fileglancer.int.janelia.org/fg/files`

Anytime the central service returns ProxiedPaths, each one now includes the base URL for fetching proxied files.

@StephanPreibisch @neomorphic @allison-truhlar 