### PR TITLE
fix: documentation in config.yaml.template

### DIFF
--- a/config.yaml.template
+++ b/config.yaml.template
@@ -10,6 +10,7 @@ db_url: sqlite:///fileglancer.db
 
 # 
 # If true, use seteuid/setegid for file access
+# Set to False for local testing
 #
 use_access_flags: True
 

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -15,10 +15,10 @@ use_access_flags: True
 
 #
 # File share mount paths to view in the UI. 
-# (this setting is ignored if confluence_url is set below)
+# (this setting will override confluence_url, set below)
 #
-file_share_mounts:
-  - /tmp
+# file_share_mounts:
+#   - /tmp
 
 #
 # Confluence URL


### PR DESCRIPTION
As of commit 094ae66, the `file_share_mounts` override the `confluence_url`, if set. Added a comment to indicate this in config.yaml.template.

I also added comments to indicate that `use_access_flags` should be set to `False` for local testing. Otherwise, viewing proxied paths from localhost in Neuroglancer doesn't work.