### PR TITLE
Ticket methods

### DIFF
--- a/fileglancer_central/app.py
+++ b/fileglancer_central/app.py
@@ -185,21 +185,60 @@ def create_app(settings):
         return FileSharePathResponse(paths=paths)
 
 
-    @app.post("/ticket", response_model=str,
+    @app.post("/ticket", response_model=Ticket,
               description="Create a new ticket and return the key")
     async def create_ticket(
+        username: str,
+        fsp_name: str,
+        path: str,
         project_key: str,
         issue_type: str,
         summary: str,
         description: str
     ) -> str:
-        ticket = create_jira_ticket(
-            project_key=project_key,
-            issue_type=issue_type, 
-            summary=summary,
-            description=description
-        )
-        return ticket['key']
+        try:
+            # Make ticket on JIRA
+            jiraTicket = create_jira_ticket(
+                project_key=project_key,
+                issue_type=issue_type, 
+                summary=summary,
+                description=description
+            )
+            if not jiraTicket or 'key' not in jiraTicket:
+                raise HTTPException(status_code=500, detail="Failed to create JIRA ticket")
+            
+            # Save the ticket in the database
+            with db.get_db_session(settings.db_url) as session:
+                dbTicket = db.create_ticket_entry(
+                    session=session,
+                    username=username,
+                    fsp_name=fsp_name,
+                    path=path,
+                    ticket_key=jiraTicket['key']
+                )
+                if dbTicket is None:
+                    raise HTTPException(status_code=500, detail="Failed to create ticket entry in database")
+                
+            # Get the full ticket details using the key
+            ticket_details = get_jira_ticket_details(jiraTicket['key'])
+        
+            return Ticket(
+                username=username,
+                fsp_name=fsp_name,
+                path=path,
+                key=ticket_details['key'],
+                created=ticket_details['created'],
+                updated=ticket_details['updated'],
+                status=ticket_details['status'],
+                resolution=ticket_details['resolution'],
+                description=ticket_details['description'],
+                link=ticket_details['link'],
+                comments=ticket_details['comments']
+            )
+         
+        except Exception as e:
+            logger.error(f"Error creating ticket: {e}")
+            raise HTTPException(status_code=500, detail=str(e))
     
 
     @app.get("/ticket/{ticket_key}", response_model=Ticket, 

--- a/fileglancer_central/app.py
+++ b/fileglancer_central/app.py
@@ -241,17 +241,30 @@ def create_app(settings):
             raise HTTPException(status_code=500, detail=str(e))
     
 
-    @app.get("/ticket/{ticket_key}", response_model=Ticket, 
-             description="Retrieve a ticket by its key")
-    async def get_ticket(ticket_key: str):
-        try:
-            return get_jira_ticket_details(ticket_key)
-        except Exception as e:
-            if str(e) == "Issue Does Not Exist":
-                raise HTTPException(status_code=404, detail=str(e))
-            else:
-                raise HTTPException(status_code=500, detail=str(e))
-
+    @app.get("/ticket/{username}", response_model=List[Ticket], 
+             description="Retrieve tickets for a user")
+    async def get_tickets(username: str = Path(..., description="The username of the user who created the tickets"),
+                          fsp_name: Optional[str] = Query(None, description="The name of the file share path that the ticket is associated with"),
+                          path: Optional[str] = Query(None, description="The path that the ticket is associated with")):
+        with db.get_db_session(settings.db_url) as session:
+            tickets = db.get_tickets(session, username, fsp_name, path)
+            if not tickets:
+                raise HTTPException(status_code=404, detail="No tickets found for this user")
+            for ticket in tickets:
+                try:
+                    ticket_details = get_jira_ticket_details(ticket.ticket_key)
+                    ticket.key = ticket_details['key']
+                    ticket.created = ticket_details['created']
+                    ticket.updated = ticket_details['updated']
+                    ticket.status = ticket_details['status']
+                    ticket.resolution = ticket_details['resolution']
+                    ticket.description = ticket_details['description']
+                    ticket.link = ticket_details['link']
+                    ticket.comments = ticket_details['comments']
+                except Exception as e:
+                    logger.error(f"Error retrieving details for ticket {ticket.ticket_key}: {e}")
+            return tickets 
+        
 
     @app.delete("/ticket/{ticket_key}",
                 description="Delete a ticket by its key")

--- a/fileglancer_central/database.py
+++ b/fileglancer_central/database.py
@@ -290,6 +290,19 @@ def delete_proxied_path(session: Session, username: str, sharing_key: str):
     session.commit()
 
 
+def get_tickets(session: Session, username: str, fsp_name: str = None, path: str = None) -> List[TicketDB]:
+    """Get tickets for a user, optionally filtered by fsp_name and path"""
+    logger.info(f"Getting tickets for {username} with fsp_name={fsp_name} and path={path}")
+    query = session.query(TicketDB).filter_by(username=username)
+    if fsp_name:
+        logger.info(f"Filtering by fsp_name={fsp_name}")
+        query = query.filter_by(fsp_name=fsp_name)
+    if path:
+        logger.info(f"Filtering by path={path}")
+        query = query.filter_by(path=path)
+    return query.all()
+
+
 def create_ticket_entry(session: Session, username: str, fsp_name: str, path: str, ticket_key: str) -> TicketDB:
     """Create a new ticket entry in the database"""
     now = datetime.now(UTC)

--- a/fileglancer_central/database.py
+++ b/fileglancer_central/database.py
@@ -64,6 +64,25 @@ class ProxiedPathDB(Base):
     )
 
 
+class TicketDB(Base):
+    """Database model for storing proxied paths"""
+    __tablename__ = 'tickets'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    username = Column(String, nullable=False)
+    fsp_name = Column(String, nullable=False)
+    path = Column(String, nullable=False)
+    ticket_key = Column(String, nullable=False, unique=True)
+    created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
+    updated_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+    
+    # TODO: Do we want to only allow one ticket per path?
+    # Commented out now for testing purposes
+    # __table_args__ = (
+    #     UniqueConstraint('username', 'fsp_name', 'path', name='uq_ticket_path'),
+    # )
+
+
 def get_db_session(db_url):
     """Create and return a database session"""
     engine = create_engine(db_url)
@@ -270,3 +289,18 @@ def delete_proxied_path(session: Session, username: str, sharing_key: str):
     session.query(ProxiedPathDB).filter_by(username=username, sharing_key=sharing_key).delete()
     session.commit()
 
+
+def create_ticket_entry(session: Session, username: str, fsp_name: str, path: str, ticket_key: str) -> TicketDB:
+    """Create a new ticket entry in the database"""
+    now = datetime.now(UTC)
+    ticket = TicketDB(
+        username=username,
+        fsp_name=fsp_name,
+        path=path,
+        ticket_key=ticket_key,
+        created_at=now,
+        updated_at=now
+    )
+    session.add(ticket)
+    session.commit()
+    return ticket

--- a/fileglancer_central/model.py
+++ b/fileglancer_central/model.py
@@ -73,6 +73,15 @@ class TicketComment(BaseModel):
 
 class Ticket(BaseModel):
     """A JIRA ticket"""
+    username: str = Field(
+        description="The username of the user who created the ticket"
+    )
+    path: str = Field(
+        description="The path of the file the ticket was created for, relative to the file share path mount point"
+    )
+    fsp_name: str = Field(
+        description="The name of the file share path associated with the file this ticket was created for"
+    )
     key: str = Field(
         description="The key of the ticket"
     )


### PR DESCRIPTION
ClickUp id: #86a84rg4u

Changes to fileglancer_central necessary to enable the [ticket workflow MVP in Fileglancer](https://github.com/JaneliaSciComp/fileglancer/pull/99). 

feat: add ticket db; update ticket model
- Add TicketDB model for storing ticket information in the database
- Implement create_ticket_entry function for database operations
- Extend Ticket model with additional fields: username, path, fsp_name
- Update ticket creation endpoint to return full ticket details

feat: add ticket retrieval and database query
Analogous to proxied paths:
- implement endpoint to retrieve tickets for a user
- add filtering options by file share path and associated path
- create database function to query tickets with optional filters

@neomorphic 