### PR TITLE
Handle wiki outages

### DIFF
--- a/fileglancer_central/app.py
+++ b/fileglancer_central/app.py
@@ -34,14 +34,15 @@ def _cache_wiki_paths(db_url, confluence_url, confluence_token, force_refresh=Fa
         if not last_refresh or (datetime.now() - last_refresh.db_last_updated).days >= 1 or force_refresh:
             logger.info("Last refresh was more than a day ago, checking for updates...")
             
-            # Get updated paths from the wiki
-            table, table_last_updated = get_wiki_table(confluence_url, confluence_token)
-
-            new_paths = convert_table_to_file_share_paths(table)
-
-            if not last_refresh or table_last_updated != last_refresh.source_last_updated:
-                logger.info("Wiki table has changed, refreshing file share paths...")
-                db.update_file_share_paths(session, new_paths, table_last_updated)
+            try:
+                # Get updated paths from the wiki
+                table, table_last_updated = get_wiki_table(confluence_url, confluence_token)
+                new_paths = convert_table_to_file_share_paths(table)
+                if not last_refresh or table_last_updated != last_refresh.source_last_updated:
+                    logger.info("Wiki table has changed, refreshing file share paths...")
+                    db.update_file_share_paths(session, new_paths, table_last_updated)
+            except Exception as e:
+                logger.error(f"Error updating wiki paths: {e}")
 
         return [FileSharePath(
             name=path.name,

--- a/fileglancer_central/database.py
+++ b/fileglancer_central/database.py
@@ -206,10 +206,8 @@ def get_proxied_paths(session: Session, username: str, fsp_name: str = None, pat
     logger.info(f"Getting proxied paths for {username} with fsp_name={fsp_name} and path={path}")
     query = session.query(ProxiedPathDB).filter_by(username=username)
     if fsp_name:
-        logger.info(f"Filtering by fsp_name={fsp_name}")
         query = query.filter_by(fsp_name=fsp_name)
     if path:
-        logger.info(f"Filtering by path={path}")
         query = query.filter_by(path=path)
     return query.all()
 
@@ -295,10 +293,8 @@ def get_tickets(session: Session, username: str, fsp_name: str = None, path: str
     logger.info(f"Getting tickets for {username} with fsp_name={fsp_name} and path={path}")
     query = session.query(TicketDB).filter_by(username=username)
     if fsp_name:
-        logger.info(f"Filtering by fsp_name={fsp_name}")
         query = query.filter_by(fsp_name=fsp_name)
     if path:
-        logger.info(f"Filtering by path={path}")
         query = query.filter_by(path=path)
     return query.all()
 


### PR DESCRIPTION
With the Wiki being migrated the API returns an error and there are no file share paths displayed which makes Fileglancer unusable. 

I've modified it to defensively catch these types of issues and at least return the current paths in the database.

It's still not ideal because the timeout takes a long time. Ideally, the wiki refresh should be run in a different thread. I added a new ticket to address this later. 

@neomorphic @allison-truhlar @StephanPreibisch 