### PR TITLE
Atlassian cloud integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ See [fileglancer-hub](https://github.com/JaneliaSciComp/fileglancer-hub) for det
 > [!NOTE]
 > Currently, the file share paths are only pulled from a Confluence Wiki. Future implementations may allow for other sources of file share paths.
 
-To pull file share paths from Janelia's Confluence wiki, configure the `confluence_url` in the `config.yaml` file. You also need a Confluence token. Under the "User" menu in the upper right corner of the Confluence UI, click "Settings" and then "Personal Access Tokens". Click "Create token" and give it a name like "Fileglancer Central". Copy the token, then create a `.env` file in the repo root with the following content:
+To pull file share paths from Janelia's Confluence wiki, configure the `atlassian_url` in the `config.yaml` file. You also need a Confluence token. Under the "User" menu in the upper right corner of the Confluence UI, click "Profile" and then "Security" and then "Create and manage API tokens". Click "Create API token" and give it a name like "Fileglancer". Copy the token, then create a `.env` file in the repo root with the following content:
 
 ```
-FGC_CONFLUENCE_TOKEN=your_confluence_token
+FGC_ATLASSIAN_USERNAME=your_email
+FGC_ATLASSIAN_TOKEN=your_confluence_token
 ```
 
 You should set the permissions on the `.env` file so that only the owner can read it:
@@ -53,11 +54,8 @@ chmod 600 .env
 > [!NOTE]
 > Currently, tickets are handled using JIRA. Future implementations may allow for other sources of ticket management systems.
 
-Certain actions are handled using a ticket system so that they can be completed manually, such as complex file conversions. To configure JIRA, set the `jira_url` in the `config.yaml` and specify your token in the `.env` file as follows:
+Certain actions are handled using a ticket system so that they can be completed manually, such as complex file conversions. To configure JIRA, use the same actions as for the wiki. If necessary, you can customize the JIRA path used for ticket links by overriding `jira_browse_url`.
 
-```
-FGC_JIRA_TOKEN=your_jira_token
-```
 
 ## Architecture
 

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -16,10 +16,15 @@ use_access_flags: True
 
 #
 # File share mount paths to view in the UI. 
-# (this setting will override confluence_url, set below)
+# (this setting will override atlassian_url, set below)
 #
 # file_share_mounts:
 #   - /tmp
+
+#
+# Atlassian Cloud URL. Used for retrieving file share paths and tickets.
+#
+#atlassian_url: https://YOURID.atlassian.net
 
 #
 # External URL for proxied paths

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -22,16 +22,6 @@ use_access_flags: True
 #   - /tmp
 
 #
-# Confluence URL
-#
-confluence_url: https://wikis.janelia.org 
-
-#
-# JIRA URL
-#
-jira_url: https://issues.hhmi.org/issues
-
-#
 # External URL for proxied paths
 #
 external_proxy_url: http://localhost:7878/files

--- a/fileglancer_central/issues.py
+++ b/fileglancer_central/issues.py
@@ -11,13 +11,14 @@ settings = get_settings()
 DEBUG = False
 
 def get_jira_client() -> Jira:
-    jira_server = settings.jira_url
-    jira_token = settings.jira_token
+    jira_server = str(settings.atlassian_url)
+    jira_username = settings.atlassian_username
+    jira_token = settings.atlassian_token
 
     if not all([jira_server, jira_token]):
         raise ValueError("Missing required JIRA credentials in environment variables")
     
-    return Jira(url=jira_server, token=jira_token)
+    return Jira(url=jira_server, username=jira_username, password=jira_token, cloud=True)
 
 
 def create_jira_ticket(summary: str, description: str, project_key: str, issue_type: str) -> str:
@@ -85,7 +86,7 @@ def get_jira_ticket_details(ticket_key: str) -> dict:
         'status': status, # E.g. "Waiting for support", "In Progress", "Resolved"
         'resolution': resolution, # E.g. "Unresolved", "Fixed"
         'description': description,
-        'link': f"{settings.jira_url}/browse/{ticket_key}",
+        'link': f"{settings.jira_browse_url}/{ticket_key}",
         'comments': [{
             'author_name': c['author']['name'],
             'author_display_name': c['author']['displayName'],

--- a/fileglancer_central/wiki.py
+++ b/fileglancer_central/wiki.py
@@ -22,15 +22,23 @@ settings = get_settings()
 confluence_space = "SCS"
 confluence_page = "Lab and Project File Share Paths"
 
+
 def parse_iso_timestamp(timestamp):
     """Parse ISO format timestamp string to datetime object"""
     return datetime.fromisoformat(timestamp)
 
 
-def get_wiki_table(confluence_url, confluence_token):
+def get_confluence_client() -> Confluence:
+    confluence_server = str(settings.atlassian_url)
+    confluence_username = settings.atlassian_username
+    confluence_token = settings.atlassian_token
+    return Confluence(url=confluence_server, username=confluence_username, password=confluence_token, cloud=True)
+
+
+def get_wiki_table():
     """Fetch and parse the file share paths table from the wiki"""
-    confluence = Confluence(url=str(confluence_url), token=confluence_token)
-    
+    confluence = get_confluence_client()
+
     page = confluence.get_page_by_title(confluence_space, confluence_page)
     page_id = page['id']
     page = confluence.get_page_by_id(page_id, status=None, version=None,


### PR DESCRIPTION
With the move to Atlassian cloud, I had to change the way we connect to Wiki and JIRA. What's nice is that there is now just a single token necessary, but you also have to pass in the username. I also took the opportunity to standardize how this works across both of the services.

@StephanPreibisch @allison-truhlar @neomorphic @cgoina 