### PR TITLE
fix: update notifications file path to use working directory

### DIFF
--- a/fileglancer_central/app.py
+++ b/fileglancer_central/app.py
@@ -234,8 +234,9 @@ def create_app(settings):
              description="Get all active notifications")
     async def get_notifications() -> NotificationResponse:
         try:
-            # Read notifications from YAML file
-            notifications_file = os.path.join(os.path.dirname(__file__), "..", "notifications.yaml")
+            # Read notifications from YAML file in current working directory
+            notifications_file = os.path.join(os.getcwd(), "notifications.yaml")
+            logger.debug(f"Looking for notifications file at: {notifications_file}")
 
             with open(notifications_file, "r") as f:
                 data = yaml.safe_load(f)


### PR DESCRIPTION
- Changes notifications.yaml path from relative to package location to current working directory
- Adds debug logging to show the resolved file path for troubleshooting
- Use os.getcwd() to explicitly reference the working directory where the service runs

This fixes the "Notifications file not found" error in service deployments where
the working directory differs from the package installation location.

@krokicki 