### PR TITLE
Tell Alembic to not disable existing loggers

### DIFF
--- a/fileglancer_central/alembic/env.py
+++ b/fileglancer_central/alembic/env.py
@@ -18,7 +18,9 @@ config = context.config
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    # The extra parameter here is crucial to prevent the access loggers from being disabled. 
+    # See https://stackoverflow.com/questions/78780118/how-can-i-stop-the-alembic-logger-from-deactivating-my-own-loggers-after-using-a
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # add your model's MetaData object here
 # for 'autogenerate' support


### PR DESCRIPTION
I noticed that access logs are not working and certain exceptions (e.g. internal server errors) are being swallowed whole.

Claude was no help with this, but StackOverflow has the right answer:
https://stackoverflow.com/questions/78780118/how-can-i-stop-the-alembic-logger-from-deactivating-my-own-loggers-after-using-a

Now I have the access logging, Uvicorn logs, and our custom logs, along with the Alembic logs:
```
2025-09-11 15:39:26.716 | INFO     | fileglancer_central.app:lifespan:153 - Initializing database...
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
2025-09-11 15:39:26.850 | INFO     | fileglancer_central.database:run_alembic_upgrade:143 - Alembic migrations completed successfully
2025-09-11 15:39:26.850 | INFO     | fileglancer_central.app:lifespan:156 - Server ready
INFO:     Application startup complete.
2025-09-11 15:40:07.210 | WARNING  | fileglancer_central.app:get_notifications:283 - Notifications file not found
INFO:     10.40.2.142:38954 - "GET /notifications HTTP/1.1" 200 OK
```

@neomorphic @allison-truhlar 