### PR TITLE
fix: do not carry over last valid value for groups in the fsp table

### DIFF
--- a/fileglancer_central/wiki.py
+++ b/fileglancer_central/wiki.py
@@ -61,9 +61,13 @@ def get_file_share_paths() -> tuple[list[dict], datetime]:
     # Fill missing values in the table from above values
     for column in table.columns:
         last_valid_value = None
-        for index, value in table[column].items():
-            if pd.isna(value):
+        for index, value in table[column].items():  
+            if column != 'group' and pd.isna(value):
                 table.at[index, column] = last_valid_value
+            elif column == 'group' and table.at[index, 'lab'] == 'Public share':
+                table.at[index, column] = 'public'
+            elif column == 'group' and (pd.isna(value) or value == ''):
+                table.at[index, column] = ''
             else:
                 last_valid_value = value
     


### PR DESCRIPTION
This PR is required to complete Clickup id: 86aagg1rp
@krokicki 
It corrects the group values in the cases where the group value is empty in the Lab and File Share Path [wiki page](https://hhmi.atlassian.net/wiki/spaces/SCS/pages/152469629/Lab+and+Project+File+Share+Paths). Previously, the group value in these cases was assigned to the last valid group value, resulting in some file share paths being in the wrong group. Now, in the case of the public file share, the group is set to public; in the case of all other file share paths with an empty group value, the group is set to ''. For other columns, the previous logic is preserved. This is necessary because in the wiki page, the lab name is only listed for the first file share path in the series of rows with file share paths that below to the same lab.